### PR TITLE
Make gen dir if missing

### DIFF
--- a/src/build.jl
+++ b/src/build.jl
@@ -166,7 +166,7 @@ function write_input_markdown(project; skip_index=false)::String
         @warn "$(dir) directory doesn't exist. Did you run `gen()`?"
         mkpath(dir)
     end
-    markdown_path = joinpath(Books.GENERATED_DIR, "input.md")
+    markdown_path = joinpath(dir, "input.md")
     write(markdown_path, text)
     return markdown_path
 end

--- a/src/build.jl
+++ b/src/build.jl
@@ -161,6 +161,11 @@ function write_input_markdown(project; skip_index=false)::String
     texts = read.(files, String)
     texts = embed_output.(texts)
     text = join(texts, '\n')
+    dir = Books.GENERATED_DIR
+    if !isdir(dir)
+        @warn "$(dir) directory doesn't exist. Did you run `gen()`?"
+        mkpath(dir)
+    end
     markdown_path = joinpath(Books.GENERATED_DIR, "input.md")
     write(markdown_path, text)
     return markdown_path


### PR DESCRIPTION
Fixes #248.

The error is now a warning:
```
julia> html()
┌ Warning: _gen doesn't exist. Did you run `gen()`?
└ @ Books ~/git/Books.jl/src/build.jl:166
[...]
```
 