### PR TITLE
Reduce menu cutoff threshold

### DIFF
--- a/defaults/style.css
+++ b/defaults/style.css
@@ -7,7 +7,7 @@
   --tiny-size: 11px;
   --block-background: hsl(0, 0%, 96%);
   --output-background: hsl(120, 100%, 94%);
-  --menu-width: 220px;
+  --menu-width: 224px;
   --max-body-width: 960px;
   --content-left-margin: 62px;
 }

--- a/src/html.jl
+++ b/src/html.jl
@@ -130,7 +130,8 @@ function html_page_name(html)
 end
 
 function html_href(text, link, level)
-    threshold = 41
+    # Note that this is related to menu-width in style.css.
+    threshold = 35
     if threshold < length(text)
         shortened = text[1:threshold]::String
         text = shortened * ".."


### PR DESCRIPTION
Some menu entries were not cut off in the Books documentation and Julia Data Science. Setting the menu wider looked ugly, so this reduces the threshold again.