### PR TITLE
Add CJK support for PDF in template.tex and metadata.yml

### DIFF
--- a/defaults/metadata.yml
+++ b/defaults/metadata.yml
@@ -27,6 +27,9 @@ geometry:
 # A setting for the PDF. I don't know whether it is important.
 lang: en-US
 
+# Setting CJK font
+#CJKmainfont: Noto Serif CJK SC
+
 links-as-notes: true
 
 tags: [pandoc, Books.jl, JuliaLang]

--- a/defaults/metadata.yml
+++ b/defaults/metadata.yml
@@ -27,8 +27,8 @@ geometry:
 # A setting for the PDF. I don't know whether it is important.
 lang: en-US
 
-# Setting CJK font
-#CJKmainfont: Noto Serif CJK SC
+# Uncomment the following to enable a Chinese/Japanese/Korean (CJK) font.
+# CJKmainfont: Noto Serif CJK SC
 
 links-as-notes: true
 

--- a/defaults/template.tex
+++ b/defaults/template.tex
@@ -1,3 +1,7 @@
+$if(CJKmainfont)$
+\PassOptionsToPackage{space}{xeCJK}
+$endif$
+%
 \documentclass[
   notoc % Suppress Tufte style table of contents.
 ]{tufte-book}
@@ -51,6 +55,11 @@
   Contextuals=Alternate,
   Ligatures=NoCommon
 ]
+
+$if(CJKmainfont)$
+  \usepackage{xeCJK}
+  \setCJKmainfont[$for(CJKoptions)$$CJKoptions$$sep$,$endfor$]{$CJKmainfont$}
+$endif$
 
 $if(graphics)$
 \usepackage{graphicx}

--- a/defaults/template.tex
+++ b/defaults/template.tex
@@ -57,8 +57,8 @@ $endif$
 ]
 
 $if(CJKmainfont)$
-  \usepackage{xeCJK}
-  \setCJKmainfont[$for(CJKoptions)$$CJKoptions$$sep$,$endfor$]{$CJKmainfont$}
+\usepackage{xeCJK}
+\setCJKmainfont[$for(CJKoptions)$$CJKoptions$$sep$,$endfor$]{$CJKmainfont$}
 $endif$
 
 $if(graphics)$


### PR DESCRIPTION
Users can set CJKmainfont in metadata.yml to render CJK characters in PDF, but for now the CJKmainfont must be SYSTEM FONTS.